### PR TITLE
Add text search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ Current available filters are:
   <columnName>_gte: Greater than or equal
   <columnName>_lte: Less than or equal
   <columnName>_not_in: Not in (Receives an array of values)
+  <columnName>_contains: String contains (uses full-text-search)
+  <columnName>_not_contains: String not contains (uses full-text-search)
+  <columnName>_starts_with: String starts with
+  <columnName>_not_starts_with: String does not start with
+  <columnName>_ends_with: String ends with
+  <columnName>_not_ends_with: String does not end with
+```
+
+### Note
+
+Indexes can greatly increase the performance of filters. You should consider adding indexes for the filterable columns. A normal index should be enough, but for full-text-search filters you can add a GIN or GiST index like in the following example:
+
+```javascript
+exports.up = async (knex) => {
+  await knex.raw('CREATE INDEX posts_title_fts_index ON posts USING gin(tsvector(title))');
+};
+
+exports.down = async (knex) => {
+  await knex.raw('DROP INDEX posts_title_fts_index');
+};
 ```
 
 ## Options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-flex-filter",
-  "version": "0.2.1",
+  "version": "0.3.0-alpha",
   "description": "Flexible filtering and search for Knex queries",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/knex-flex-filter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-flex-filter",
-  "version": "0.3.0-alpha-3",
+  "version": "0.3.0-alpha-4",
   "description": "Flexible filtering and search for Knex queries",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/knex-flex-filter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-flex-filter",
-  "version": "0.3.0-alpha",
+  "version": "0.3.0-alpha-1",
   "description": "Flexible filtering and search for Knex queries",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/knex-flex-filter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-flex-filter",
-  "version": "0.3.0-alpha-1",
+  "version": "0.3.0-alpha-2",
   "description": "Flexible filtering and search for Knex queries",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/knex-flex-filter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-flex-filter",
-  "version": "0.3.0-alpha-2",
+  "version": "0.3.0-alpha-3",
   "description": "Flexible filtering and search for Knex queries",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/knex-flex-filter",

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,6 @@ export const knexFlexFilter = (originalQuery, where = {}, opts = {}) => {
 
     // Escape apostrophes correctly
     const matchEscape = conditionMap[condition].match(/'(.*)\?(.*)'/);
-    console.log('qv', query, '--', value, '---', conditionMap[condition]);
     if (matchEscape) {
       // eslint-disable-next-line no-unused-vars
       const [_, pre, post] = matchEscape;

--- a/tests/helpers/seeds.js
+++ b/tests/helpers/seeds.js
@@ -1,29 +1,32 @@
 
 export default async (knex) => {
   const entity1 = await knex('entities').insert({
-    name: 'Owner',
+    name: 'John Doe',
     ownerId: 1,
     data: {
       id: '1',
+      name: 'John Doe',
       address: '0x2f63f292c01a179e06f5275cfe3278c1efa7a1a2',
       lastBuyBlockNumber: 5000,
     },
   });
   const entity2 = await knex('entities').insert({
-    name: 'Owner',
+    name: 'Peter Jackson',
     ownerId: 2,
     data: {
       id: '2',
+      name: 'Peter Jackson',
       address: '0x2f63f292c01a179e06f5275cfe3278c1efa7a1a3',
       lastBuyBlockNumber: 5001,
     },
   });
 
   const entity3 = await knex('entities').insert({
-    name: 'Owner',
+    name: 'Rick Sanchez',
     ownerId: 3,
     data: {
       id: '3',
+      name: 'Rick Sanchez',
       address: '0x2f63f292c01a179e06f5275cfe3278c1efa7a1a4',
       lastBuyBlockNumber: 5002,
     },


### PR DESCRIPTION
# Change log

- Added support for `contains`, `not_contains`, `starts_with`, `not_starts_with`, `ends_with` and `not_ends_with` filters.

- Tested the new text-search filters

- Updated the readme with the new filters

# TODO

Test the new filters using an aggregate function.