### PR TITLE
Add similar_to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,26 +52,30 @@ Current available filters are:
   <columnName>_gte: Greater than or equal
   <columnName>_lte: Less than or equal
   <columnName>_not_in: Not in (Receives an array of values)
-  <columnName>_contains: String contains (uses full-text-search)
-  <columnName>_not_contains: String not contains (uses full-text-search)
+  <columnName>_contains: String contains
+  <columnName>_not_contains: String not contains
   <columnName>_starts_with: String starts with
   <columnName>_not_starts_with: String does not start with
   <columnName>_ends_with: String ends with
   <columnName>_not_ends_with: String does not end with
+  <columnName>_similar_to: String is similar to
 ```
 
 ### Note
 
-Indexes can greatly increase the performance of filters. You should consider adding indexes for the filterable columns. A normal index should be enough, but for full-text-search filters you can add a GIN or GiST index like in the following example:
+`similar_to` filter requires Postgres `pg_trgm` extension. A migration that creates the extension and creates a GIN index for faster "similar to" queries can look like this:
 
 ```javascript
 exports.up = async (knex) => {
-  await knex.raw('CREATE INDEX posts_title_fts_index ON posts USING gin(tsvector(title))');
+  await knex.raw('CREATE EXTENSION pg_trgm');
+  await knex.raw('CREATE INDEX posts_title_trgm_index ON posts USING gin(title gin_trgm_ops)');
 };
 
 exports.down = async (knex) => {
-  await knex.raw('DROP INDEX posts_title_fts_index');
+  await knex.raw('DROP EXTENSION pg_trgm');
+  await knex.raw('DROP INDEX posts_title_trgm_index');
 };
+
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ const query = knexFlexFilter(
 );
 ```
 
+### caseInsensitiveSearch
+
+Set to `true` if you want to use insensitive-case searches when using `contains` or `starts_with` filters. Defaults to false.
+
 ## Contributing
 
 Make sure all the tests pass before sending a PR. To run the test suite, run `yarn test`. Please note that the codebase is using `dotenv` package to connect to a test db, so, to connect to your own, add a `.env` file inside the `tests` folder with the following structure:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-flex-filter",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha-1",
   "description": "Flexible filtering and search for Knex queries",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/knex-flex-filter",

--- a/tests/migrations/20190402152402_add_trgm_support.js
+++ b/tests/migrations/20190402152402_add_trgm_support.js
@@ -1,0 +1,9 @@
+exports.up = async (knex) => {
+  await knex.raw('CREATE EXTENSION pg_trgm');
+  await knex.raw('CREATE INDEX entities_name_trgm_index ON entities USING gin(name gin_trgm_ops)');
+};
+
+exports.down = async (knex) => {
+  await knex.raw('DROP EXTENSION pg_trgm');
+  await knex.raw('DROP INDEX entities_name_trgm_index');
+};


### PR DESCRIPTION
# Change log

- Changed `contains` filters implementations to use LIKE instead of `fts` to support partial text matches.

- Added `similar_to` filter for fuzzy-search.

- Updated the docs